### PR TITLE
#include <algorithm>

### DIFF
--- a/example/splitsinfile/splitsstructs.cpp
+++ b/example/splitsinfile/splitsstructs.cpp
@@ -1,4 +1,5 @@
 #include "splitsstructs.h"
+#include <algorithm>
 bool TreesToSplits::gTrackTrivial = false;
 bool TreesToSplits::gTreatAsRooted = false;
 bool TreesToSplits::gTrackFreq = false;


### PR DESCRIPTION
I was unable to build the project without including `<algorithm>`.

This seems to be necessary in order for `std::max` to be recognized, at least when compiling in Visual Studio on Windows 10.
