### PR TITLE
support for interleave=[yes/no]

### DIFF
--- a/ncl/nxscharactersblock.cpp
+++ b/ncl/nxscharactersblock.cpp
@@ -2180,7 +2180,29 @@ void NxsCharactersBlock::HandleFormat(
 		else if (wIt->Equals("TRANSPOSE"))
 			transposing = true;
 		else if (wIt->Equals("INTERLEAVE"))
-			interleaving = true;
+			{
+			// check if followed by =yes/no (strictly, not Nexus-compliant)
+			wIt++;
+			if (wIt->Equals("="))
+				{
+				wIt++;
+				if (wIt->Equals("YES"))
+					{
+						interleaving = true;
+					}
+				else if (wIt->Equals("NO"))
+					{
+						interleaving = false;
+					}
+				else
+					throw NxsException("Cannot parse interleave command", *wIt); // probably want a more informative error
+				}
+			else
+				{
+					wIt--;
+					interleaving = true;
+				}
+			}
 		else if (wIt->Equals("ITEMS"))
 			{
 			DemandEquals(wIt, tvEnd, "after keyword ITEMS");


### PR DESCRIPTION
NCL supports `INTERLEAVE` and `NOINTERLEAVE`, while many software (e.g., MrBayes, PAUP*, etc.) support `INTERLEAVE=YES` and `INTERLEAVE=NO` (NCL halts processing and reports an error on this). NCL follows the original Nexus definition (Maddison et al., 1997), but since so many packages support both formats it seems reasonable that NCL should as well.

This simple edit adds support for the latter to NCL (`NxsCharactersBlock::HandleFormat()`).

Note: `nxsdistancesblock.cpp` also parses interleave statements (`NxsDistancesBlock::HandleFormatCommand()`), but does so in a different way (`token.GetNextToken()` rather than iterating through a tokenized vector). Presumably a `token.PeekNextToken()` function could be added to mirror functionality above.