### PR TITLE
Fixtaxcast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.1)
 
+project(ncl)
+
 if(MSVC)
   # Force to always compile with W4
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")

--- a/ncl/nxstaxablock.cpp
+++ b/ncl/nxstaxablock.cpp
@@ -276,7 +276,7 @@ void NxsTaxaBlock::CheckCapitalizedTaxonLabel(
 	if (dimNTax < ind)
 		{
 		NxsString e;
-		e << "Number of stored labels (" (unsigned)<< taxLabels.size() << ") exceeds the NTax specified (" << dimNTax<<").";
+		e << "Number of stored labels (" << (unsigned)taxLabels.size() << ") exceeds the NTax specified (" << dimNTax<<").";
 		throw NxsException(e);
 		}
 	if (CapitalizedTaxLabelToNumber(s) != 0)

--- a/ncl/nxstaxablock.cpp
+++ b/ncl/nxstaxablock.cpp
@@ -276,7 +276,7 @@ void NxsTaxaBlock::CheckCapitalizedTaxonLabel(
 	if (dimNTax < ind)
 		{
 		NxsString e;
-		e << "Number of stored labels (" << taxLabels.size() << ") exceeds the NTax specified (" << dimNTax<<").";
+		e << "Number of stored labels (" (unsigned)<< taxLabels.size() << ") exceeds the NTax specified (" << dimNTax<<").";
 		throw NxsException(e);
 		}
 	if (CapitalizedTaxLabelToNumber(s) != 0)


### PR DESCRIPTION
Proposed fix for: https://github.com/mtholder/ncl/issues/5#issue-50547735

I keep running into the same problem ("ambiguous overload for 'operator<<'")  trying to build on Windows with latest Visual Studio. The suggested fix in the issues page was explicit cast to `long unsigned int`, but I noticed the returns from `NxsStringVector::size()` are always cast to `unsigned` elsewhere in the same file (line 304 is nearly identical and has already been cast). I suppose this was just an accidental omission that never got caught as other compilers don't seem to be bothered by this overload.

also added project name to CMakeLists which was causing warnings (and issues building on Mac).