### PR TITLE
Fix bug in reading STATELABELS command

### DIFF
--- a/ncl/nxscharactersblock.cpp
+++ b/ncl/nxscharactersblock.cpp
@@ -4551,8 +4551,10 @@ void NxsCharactersBlock::HandleStatelabels(
 	charStates.clear();
 	for (;;)
 		{
+        if (semicolonFoundInInnerLoop)
+            break;
 		token.GetNextToken();
-		if (token.Equals(";") || semicolonFoundInInnerLoop)
+		if (token.Equals(";"))
 			break;
         int n = -1;
         try {

--- a/ncl/nxscharactersblock.cpp
+++ b/ncl/nxscharactersblock.cpp
@@ -4544,13 +4544,15 @@ void NxsCharactersBlock::HandleMatrix(
 void NxsCharactersBlock::HandleStatelabels(
   NxsToken &token)	/* the token used to read from `in' */
 	{
+	bool semicolonFoundInInnerLoop = false;
+
 	if (datatype == continuous)
 		GenerateNxsException(token, "STATELABELS cannot be specified when the datatype is continuous");
 	charStates.clear();
 	for (;;)
 		{
 		token.GetNextToken();
-		if (token.Equals(";"))
+		if (token.Equals(";") || semicolonFoundInInnerLoop)
 			break;
         int n = -1;
         try {
@@ -4569,8 +4571,13 @@ void NxsCharactersBlock::HandleStatelabels(
 		for (;;)
 			{
 			token.GetNextToken();
-			if (token.Equals(";") || token.Equals(","))
+			if (token.Equals(","))
 				break;
+            if (token.Equals(";"))
+                {
+                semicolonFoundInInnerLoop = true;
+                break;
+                }
 			v.push_back(token.GetToken());
 			}
 		}


### PR DESCRIPTION
Discovered that NxsCharactersBlock couldn't handle valid Nexus files that use a combination of CHARLABELS and STATELABELS commands (the default output from Morphobank). Problem resulted from a break in an inner loop of the handler function causing the function to skip the command-terminating semicolon. In a STATELABELS command, the last entry will not be terminated by a comma. However, inner loop ends on either a semicolon or comma. This meant the outer loop would jump into the next command.

For consistency, I used a boolean "foundSemicolonInInnerLoop" as done in HandleCharstateLabels function.

