### PR TITLE
remove inheritance from std::binary_function

### DIFF
--- a/ncl/nxsstring.h
+++ b/ncl/nxsstring.h
@@ -263,7 +263,6 @@ class NStrCaseSensitiveEquals
 	Binary function class that performs case-Insensitive string compares.
 */
 struct NxsStringEqual
-//  : public std::binary_function<NxsString, NxsString, bool>
 	{
 	bool operator()(const NxsString &x, const NxsString &y) const;
 	};

--- a/ncl/nxsstring.h
+++ b/ncl/nxsstring.h
@@ -263,7 +263,7 @@ class NStrCaseSensitiveEquals
 	Binary function class that performs case-Insensitive string compares.
 */
 struct NxsStringEqual
-  : public std::binary_function<NxsString, NxsString, bool>
+//  : public std::binary_function<NxsString, NxsString, bool>
 	{
 	bool operator()(const NxsString &x, const NxsString &y) const;
 	};


### PR DESCRIPTION
This no longer seems to be needed and creates problems building with c++17 or higher. It has been deprecated since c++11. I ran the tests (thanks for updating to python3!) and all checks out and all my programs seem to work find. But you might still want to double-check.

