### PR TITLE
Replace sprintf with snprintf.

### DIFF
--- a/ncl/nxsstring.cpp
+++ b/ncl/nxsstring.cpp
@@ -213,7 +213,7 @@ NxsString &NxsString::operator+=(
 	// Create a C-string representing the supplied double value.
 	// The # causes a decimal point to always be output.
 	//
-	std::sprintf(tmp, "%#3.6f", d);
+	std::snprintf(tmp, 81, "%#3.6f", d);
 	unsigned tmplen = (unsigned)strlen(tmp);
 
 	// If the C-string has a lot of trailing zeros, lop them off
@@ -488,7 +488,7 @@ NxsString &NxsString::RightJustifyDbl(
 		erase();
 
 	char fmtstr[81];
-	sprintf(fmtstr, "%%.%df", p);
+	snprintf(fmtstr, 81, "%%.%df", p);
 	NxsString tmp;
 	tmp.PrintF(fmtstr, x);
 

--- a/ncl/nxsstring.h
+++ b/ncl/nxsstring.h
@@ -457,14 +457,14 @@ inline NxsString &NxsString::operator=(
 	}
 
 /*!
-	Uses the standard C sprintf function to append the character representation of the supplied integer i' to the stored
+	Uses the standard C snprintf function to append the character representation of the supplied integer i' to the stored
 	string (format code %d). For example, if the stored string is "taxon" and `i' is 9, the result is "taxon9".
 */
 inline NxsString &NxsString::operator+=(
   const int i)	/* the int to append */
 	{
 	char tmp[81];
-	std::sprintf(tmp, "%d", i);
+	std::snprintf(tmp, 81, "%d", i);
 	append(tmp);
 	return *this;
 	}
@@ -493,37 +493,37 @@ inline bool NxsString::Abbreviates(
 	}
 
 /*!
-	Uses standard C function std::sprintf to append the unsigned integer `i' to the stored string (format code %u).
+	Uses standard C function std::snprintf to append the unsigned integer `i' to the stored string (format code %u).
 */
 inline NxsString& NxsString::operator+=(
   unsigned i)	/* the integer to be appended */
 	{
 	char tmp[81];
-	std::sprintf(tmp, "%u", i);
+	std::snprintf(tmp, 81, "%u", i);
 	append(tmp);
 	return *this;
 	}
 
 /*!
-	Uses standard C function std::sprintf to append the long integer `l' to the stored string (format code %ld).
+	Uses standard C function std::snprintf to append the long integer `l' to the stored string (format code %ld).
 */
 inline NxsString& NxsString::operator+=(
   const long l)	/* the long integer to be appended */
 	{
 	char tmp[81];
-	std::sprintf(tmp, "%ld", l);
+	std::snprintf(tmp, 81, "%ld", l);
 	append(tmp);
 	return *this;
 	}
 
 /*!
-	Uses standard C function std::sprintf to append the unsigned long integer `l' to the stored string (format code %lu).
+	Uses standard C function std::snprintf to append the unsigned long integer `l' to the stored string (format code %lu).
 */
 inline NxsString& NxsString::operator+=(
   const unsigned long l)	/* the unsigned long integer to be appended */
 	{
 	char tmp[81];
-	std::sprintf(tmp, "%lu", l);
+	std::snprintf(tmp, 81, "%lu", l);
 	append(tmp);
 	return *this;
 	}


### PR DESCRIPTION
This gets rid of a lot of warnings on Mac.
And is also maybe safer.