### PR TITLE
Fix misleading indentation

### DIFF
--- a/ncl/nxscxxdiscretematrix.cpp
+++ b/ncl/nxscxxdiscretematrix.cpp
@@ -254,21 +254,21 @@ void NxsTransposeCompressedMatrix(
 	    }
 	const unsigned ntaxa = (unsigned const)compressedTransposedMatrix[0].stateCodes.size();
 	destination.Initialize(ntaxa, npatterns);
-    NxsCDiscreteStateSet ** matrix = destination.GetAlias();			/** taxa x characters matrix of indices of state sets */
-    if (patternCounts)
-        patternCounts->resize(npatterns);
-    if (patternWeights)
-        patternWeights->resize(npatterns);
+	NxsCDiscreteStateSet ** matrix = destination.GetAlias();			/** taxa x characters matrix of indices of state sets */
+	if (patternCounts)
+	    patternCounts->resize(npatterns);
+	if (patternWeights)
+	    patternWeights->resize(npatterns);
 	for (unsigned p = 0; p < npatterns; ++p)
 		{
 		const NxsCharacterPattern & pattern = compressedTransposedMatrix[p];
 		const std::vector<NxsCDiscreteState_t> & states = pattern.stateCodes;
 		for (unsigned t = 0; t < ntaxa; ++t)
 		    matrix[t][p] = states[t];
-        if (patternCounts)
-            (*patternCounts)[p] = pattern.count;
-        if (patternWeights)
-            (*patternWeights)[p] = pattern.sumOfPatternWeights;
+		if (patternCounts)
+		    (*patternCounts)[p] = pattern.count;
+		if (patternWeights)
+		    (*patternWeights)[p] = pattern.sumOfPatternWeights;
 		}
 }
 

--- a/ncl/nxstreesblock.cpp
+++ b/ncl/nxstreesblock.cpp
@@ -1711,8 +1711,8 @@ void NxsTreesBlock::ProcessTokenStreamIntoTree(
 				prevToken = NXS_TREE_CLADE_NAME_TOKEN;
 				}
 			}
-        if (allowUnquotedSpaces)
-	        token.SetLabileFlagBit(NxsToken::spaceDoesNotBreakToken);
+		if (allowUnquotedSpaces)
+			token.SetLabileFlagBit(NxsToken::spaceDoesNotBreakToken);
 
 		token.GetNextToken();
 		}


### PR DESCRIPTION
NCL consistently uses the Whitesmiths indentation style:

```
if (condition)
    {
    statement;
    }
```

instead of the (perhaps more common) Allman style:

```
if (condition)
{
    statement;
}
```

When the body of the conditional consists of a single line, we frequently omit braces altogether. In two places in `nxstreesblock.cpp` and `nxscxxdiscretematrix.cpp`, these features interact in a way that triggers the "misleading indentation" warning emitted by more recent versions of the GCC compiler (e.g., GCC 15):

```
../src/libs/ncl/nxstreesblock.cpp: In static member function ‘static void NxsTreesBlock::ProcessTokenStreamIntoTree(NxsToken&, NxsFullTreeDescription&, NxsLabelToIndicesMapper*, std::map<std::__cxx11::basic_string<char>, unsigned int>&, bool, NxsReader*, bool, bool, bool, bool, bool, bool)’:
../src/libs/ncl/nxstreesblock.cpp:1714:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
 1714 |         if (allowUnquotedSpaces)
      |         ^~
../src/libs/ncl/nxstreesblock.cpp:1717:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
 1717 |                 token.GetNextToken();
      |                 ^~~~~
```

This PR preserves the existing indentation style but inserts extra braces to get rid of the warning.