### PR TITLE
Fix windows compile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,9 @@ jobs:
         name: [ linux-gcc-c++17,
                 linux-gcc-c++20,
                 linux-clang-c++17,
-                linux-clang-c++20 ]
+                linux-clang-c++20,
+                windows
+                ]
         include:
           - name: linux-gcc-c++17
             compiler: gcc
@@ -38,15 +40,28 @@ jobs:
             std: c++20
             os: ubuntu-latest
 
+          - name: windows
+            compiler: idk
+            std: c++20
+            os: ubuntu-latest
+            arch: win64
+
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ matrix.image || '' }}
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install
+    - name: Install (Linux)
       run: |
         sudo apt-get install -y ccache meson cmake
+
+    - name: Install (Windows)
+      if: matrix.name == 'windows'
+      run: |
+        sudo apt-get install -y ccache meson cmake
+        sudo apt-get install -y git python3-setuptools python3-pip g++-mingw-w64 wine64
+        ${GITHUB_WORKSPACE}/scripts/make_winroot.sh -ccache true
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -65,12 +80,18 @@ jobs:
            
     - name: Build and test with meson
       run: |
-        meson setup mbuild
+        if [ "${{ matrix.name }}" = "windows" ] ; then
+          margs="--cross-file=win64-cross.txt"
+        fi
+        meson setup mbuild ${margs}
         cd mbuild
         ninja
-        ninja test
+        if [ "${{ matrix.name }}" != "windows" ] ; then
+          ninja test
+        fi
 
-    - name: Build and install and test with cmake
+    - name: Build and install and test with autoconf
+      if: matrix.name != 'windows'
       run: |
         ./bootstrap.sh
         cd ../

--- a/example/find-unsupported-edges/findunsupportededges.cpp
+++ b/example/find-unsupported-edges/findunsupportededges.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include "ncl/nxsdefs.h"
 #include "ncl/nxstreesblock.h"
+#include <cstdint>
 
 using namespace std;
 long gStrictLevel = 2;
@@ -554,10 +555,10 @@ void recordSupportedNodes(const map<const NxsSimpleNode *, set<long> > & refNdp2
 			assert(ancIt != refNdp2mrca.end());
 			const set<long> & anm = ancIt->second;
 			if (printDB) { //debugging
-				cerr << "DEBUGGING refTree node " << (long)nd << ": ";
+				cerr << "DEBUGGING refTree node " << (std::int64_t)nd << ": ";
 				writeSet(cerr, "", nm, " ");
 				cerr << "\n";
-				cerr << "refTree par " << (long)firstBranchingAnc << ": ";
+				cerr << "refTree par " << (std::int64_t)firstBranchingAnc << ": ";
 				writeSet(cerr, "", anm, " ");
 				cerr << "\n";
 			}
@@ -731,8 +732,8 @@ void markSuspectNode(const set<long> & designators) {
 
 void parseAndProcessMRCADesignatorsFile(string filepath) {
 	if (gRefTree == 0L || gTaxonTree != 0L) {
-		cerr << "gRefTree" << (long )gRefTree << "\n";
-		cerr << "gTaxonTree" << (long )gTaxonTree << "\n";
+		cerr << "gRefTree" << (std::int64_t )gRefTree << "\n";
+		cerr << "gTaxonTree" << (std::int64_t )gTaxonTree << "\n";
 		cerr << "\nDesignators file must come after the full tree estimate, but before the taxonomy in the argument length\n";
 		throw exception();
 	}

--- a/scripts/make_winroot.sh
+++ b/scripts/make_winroot.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# parse command line arguments
+while echo $1 | grep ^- > /dev/null; do
+    # intercept help while parsing "-key value" pairs
+    if [ "$1" = "--help" ] || [ "$1" = "-h" ]
+    then
+        echo 'Command line options are:
+-h                              : print this help and exit.
+-download        <true|false>   : download MINGW packages.
+
+Example:
+  ./make_winroot.sh -help true'
+        exit
+    fi
+
+    # parse pairs
+    eval $( echo $1 | sed 's/-//g' | tr -d '\012')=$2
+    shift
+    shift
+done
+
+SYSROOT=$HOME/win_root
+
+# 1. Make sysroot
+echo
+echo "1. Writing sysroot dir ${SYSROOT}"
+mkdir -p "${SYSROOT}"
+mkdir -p "${SYSROOT}/bin"
+
+# 2. Generate cross file
+CROSSNAME=win64-cross.txt
+echo
+echo "2. Writing cross file to '${CROSSNAME}'"
+
+cat > "${CROSSNAME}" <<EOF
+[binaries]
+c = ['ccache','x86_64-w64-mingw32-gcc-posix']
+cpp = ['ccache','x86_64-w64-mingw32-g++-posix']
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
+pkg-config = 'pkg-config'
+exe_wrapper = 'wine' # A command used to run generated executables.
+
+# why do we still need these? shouldn't they get added automatically if we find boost?
+[built-in options]
+c_args = ['-I${SYSROOT}/mingw64/include']
+c_link_args = ['-L${SYSROOT}/mingw64/lib']
+
+cpp_args = ['-I${SYSROOT}/mingw64/include']
+cpp_link_args = ['-L${SYSROOT}/mingw64/lib']
+
+[properties]
+sys_root = '${SYSROOT}'
+pkg_config_libdir = '${SYSROOT}/mingw64/lib/pkgconfig'
+boost_root='${SYSROOT}/mingw64'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+EOF
+
+# 3. Download packages
+if [ "$download" = "false" ] ; then
+    echo
+    echo "(3.) Skipping installation of packages to ${SYSROOT}."
+    echo
+else
+
+    echo
+    echo "3. Installing packages to ${SYSROOT}"
+    echo
+cd ${SYSROOT}
+
+# Note that the use of gcc-posix and g++-posix means that we need
+# *-posix/libgcc_s_seh-1.dll and *-posix2/libstdc++-6.dll instead
+# of the *-win32/ versions.
+PKGS="boost-1.89.0-1
+boost-libs-1.89.0-1"
+
+# We're going to use the /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll instead of downloading winpthread.
+
+for PKG in ${PKGS} ; do
+    FILE=mingw-w64-x86_64-${PKG}-any.pkg.tar.zst
+    if [ -e "${FILE}" ] ; then
+        echo "   ${PKG} already downloaded and installed."
+    else
+        URL="http://repo.msys2.org/mingw/x86_64/${FILE}"
+        if ! wget --no-verbose --show-progress "${URL}" ; then
+            echo "Failed to download ${URL}"
+            exit
+        fi
+        if tar -I zstd -xf ${FILE} ; then
+            echo "${PKG} installed"
+        else
+            rm ${FILE}
+            echo "Failed to install ${PKG}"
+            echo
+            echo "Perhaps the decompression program zstd is not installed?"
+            echo "Try 'sudo apt install zstd'."
+            exit
+        fi
+    fi
+done
+fi
+
+echo
+echo "Done."
+echo


### PR DESCRIPTION
Apparently NCL is casting pointers to `long`, which fails on windows64 because `long` is only 32 bits there and cannot fit a pointer.  This is then causing failures trying to build tensorphylo on windows.

Ideally we'd go through and convert `long` -> `std::int64_t` and `unsigned long` -> `std::uing64_t` just like we did with revbayes.  But this PR is a first step to make NCL compile on windows.